### PR TITLE
Fix a few terraform 12 edge cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /composer.lock
 
 /.phplint-cache
+
+/temp*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 > Sections: (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`)
 
+## [1.2.1] - 2020-04-14
+
+### Fixed
+
+- Terraform 0.12 Attributes containing a suffix of `# whitespace changes` will no longer raise errors.
+  > Example output of a plan:
+  > ```
+  > -/+ resource "aws_sns_topic" "sns_topic" {
+  >       ~ arn                                      = "arn:aws:sns:us-east-2:my-resource" -> (known after apply)
+  >       ~ delivery_policy                          = jsonencode( # whitespace changes
+  >             {
+  >                 http = {
+  >                     defaultHealthyRetryPolicy    = {
+  >                         maxDelayTarget     = 20
+  >                         numRetries         = 3
+  >                     }
+  >                 }
+  >             }
+  >         )
+  >     }
+  > ```
+
+- Terraform 0.12 Resources containing `(deposed object XXXXXXXX)` will no longer raise errors.
+  > Example output of a plan:
+  > ```
+  > # aws_alb_target_group.ecs[0] (deposed object 08221b78) will be destroyed
+  > - resource "aws_alb_target_group" "ecs" {
+  >     - arn    = "arn:aws:elasticloadbalancing:us-west-2:my-resource" -> null
+  >     - name   = "ecs-myapp" -> null
+  >   }
+  > ```
+
 ## [1.2.0] - 2020-01-23
 
 ### Fixed

--- a/src/Parsers/Terraform12AttributeParser.php
+++ b/src/Parsers/Terraform12AttributeParser.php
@@ -21,6 +21,7 @@ class Terraform12AttributeParser
 
     const OLD_NEW_SEPARATOR = ' -> ';
     const FORCES_NEW_RESOURCE_SUFFIX = ' # forces replacement';
+    const WHITESPACE_SUFFIX = ' # whitespace changes';
 
     const TYPE_STRING = 'string';
     const TYPE_COMPUTED = 'computed';
@@ -93,10 +94,7 @@ class Terraform12AttributeParser
      */
     public function isOpeningMultiLineTag($line): ?string
     {
-        $suffixIndex = strlen(self::FORCES_NEW_RESOURCE_SUFFIX) * -1;
-        if (substr($line, $suffixIndex) === self::FORCES_NEW_RESOURCE_SUFFIX) {
-            $line = substr($line, 0, $suffixIndex);
-        }
+        $line = $this->cleanLineFromSuffixes($line);
 
         if (preg_match(self::ATTRIBUTE_LINE_REGEX, $line) === 1) {
             foreach (array_keys(self::MULTILINE_OPENERS) as $opener) {
@@ -125,10 +123,7 @@ class Terraform12AttributeParser
      */
     public function isStandardAttribute($line)
     {
-        $suffixIndex = strlen(self::FORCES_NEW_RESOURCE_SUFFIX) * -1;
-        if (substr($line, $suffixIndex) === self::FORCES_NEW_RESOURCE_SUFFIX) {
-            $line = substr($line, 0, $suffixIndex);
-        }
+        $line = $this->cleanLineFromSuffixes($line);
 
         if (preg_match(self::ATTRIBUTE_LINE_REGEX, $line) !== 1) {
             return false;
@@ -410,6 +405,26 @@ class Terraform12AttributeParser
         }
 
         return null;
+    }
+
+    /**
+     * @param string $line
+     *
+     * @return line
+     */
+    private function cleanLineFromSuffixes($line)
+    {
+        $suffixIndex = strlen(self::FORCES_NEW_RESOURCE_SUFFIX) * -1;
+        if (substr($line, $suffixIndex) === self::FORCES_NEW_RESOURCE_SUFFIX) {
+            $line = substr($line, 0, $suffixIndex);
+        }
+
+        $suffixIndex = strlen(self::WHITESPACE_SUFFIX) * -1;
+        if (substr($line, $suffixIndex) === self::WHITESPACE_SUFFIX) {
+            $line = substr($line, 0, $suffixIndex);
+        }
+
+        return $line;
     }
 
     /**

--- a/src/Parsers/Terraform12ResourceParser.php
+++ b/src/Parsers/Terraform12ResourceParser.php
@@ -28,8 +28,9 @@ class Terraform12ResourceParser
         '/^' .
             '#{1}' .
         '\ ' .
-            '([^ ]+)' .             # full name
-            '( is tainted\, so)?' . # tainted (optional)
+            '([^ ]+)' .                            # full name
+            '( is tainted\, so)?' .                # tainted (optional)
+            '( \(deposed object [a-z0-9]+\))?' .   # is deposed (optional)
         '\ ' .
             '(?:will|must) be' .
         '\ ' .
@@ -118,7 +119,8 @@ class Terraform12ResourceParser
 
         $name = $matches[0];
         $isTainted = $matches[1] ? true : false;
-        $symbol = $matches[2];
+        $isDeposed = $matches[2] ? true : false;
+        $symbol = $matches[3];
 
         return $this->parseResource($symbol, $name, $isTainted);
     }

--- a/tests/.fixtures-0.12/66-whitespace-changes.expected.json
+++ b/tests/.fixtures-0.12/66-whitespace-changes.expected.json
@@ -1,0 +1,62 @@
+{
+    "errors": [],
+    "changedResources": [
+        {
+            "action": "replace",
+            "name": "default",
+            "type": "aws_ecr_lifecycle_policy",
+            "fully_qualified_name": "aws_ecr_lifecycle_policy.default",
+            "module_path": "",
+            "is_new": false,
+            "is_tainted": false,
+            "attributes": {
+                "id": {
+                    "name": "id",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "string",
+                        "value": "my-policy-name"
+                    },
+                    "new": {
+                        "type": "computed",
+                        "value": null
+                    }
+                },
+                "policy": {
+                    "name": "policy",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "unknown",
+                        "value": null
+                    }
+                },
+                "registry_id": {
+                    "name": "registry_id",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "string",
+                        "value": "0001000200030004"
+                    },
+                    "new": {
+                        "type": "computed",
+                        "value": null
+                    }
+                },
+                "repository": {
+                    "name": "repository",
+                    "force_new_resource": true,
+                    "old": {
+                        "type": "string",
+                        "value": "repo-name-1"
+                    },
+                    "new": {
+                        "type": "string",
+                        "value": "repo-name-2"
+                    }
+                }
+            }
+        }
+    ],
+    "modules": []
+}

--- a/tests/.fixtures-0.12/66-whitespace-changes.stdout.txt
+++ b/tests/.fixtures-0.12/66-whitespace-changes.stdout.txt
@@ -1,0 +1,34 @@
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+------------------------------------------------------------------------
+
+Terraform will perform the following actions:
+
+  # aws_ecr_lifecycle_policy.default must be replaced
+-/+ resource "aws_ecr_lifecycle_policy" "default" {
+      ~ id          = "my-policy-name" -> (known after apply)
+      ~ policy      = jsonencode( # whitespace changes
+            {
+                rules = [
+                    {
+                        action       = {
+                            type = "expire"
+                        }
+                        description  = "Expire images more than 60 versions old"
+                        rulePriority = 1
+                        selection    = {
+                            countNumber = 60
+                            countType   = "imageCountMoreThan"
+                            tagStatus   = "any"
+                        }
+                    },
+                ]
+            }
+        )
+      ~ registry_id = "0001000200030004" -> (known after apply)
+      ~ repository  = "repo-name-1" -> "repo-name-2" # forces replacement
+    }
+
+Plan: 0 to add, 1 to change, 0 to destroy.

--- a/tests/.fixtures-0.12/67-deposed.expected.json
+++ b/tests/.fixtures-0.12/67-deposed.expected.json
@@ -1,0 +1,193 @@
+{
+    "errors": [],
+    "changedResources": [
+        {
+            "action": "destroy",
+            "name": "ecs[0]",
+            "type": "aws_alb_target_group",
+            "fully_qualified_name": "aws_alb_target_group.ecs[0]",
+            "module_path": "",
+            "is_new": false,
+            "is_tainted": false,
+            "attributes": {
+                "arn": {
+                    "name": "arn",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "string",
+                        "value": "arn:aws:elasticloadbalancing:us-west-2:0001000200030004:targetgroup/ecs-myapp/abcdefxyz"
+                    },
+                    "new": {
+                        "type": "null",
+                        "value": null
+                    }
+                },
+                "deregistration_delay": {
+                    "name": "deregistration_delay",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "number",
+                        "value": "10"
+                    },
+                    "new": {
+                        "type": "null",
+                        "value": null
+                    }
+                },
+                "id": {
+                    "name": "id",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "string",
+                        "value": "arn:aws:elasticloadbalancing:us-west-2:0001000200030004:targetgroup/ecs-myapp/abcdefxyz"
+                    },
+                    "new": {
+                        "type": "null",
+                        "value": null
+                    }
+                },
+                "name": {
+                    "name": "name",
+                    "force_new_resource": false,
+                    "old": {
+                        "type": "string",
+                        "value": "ecs-myapp"
+                    },
+                    "new": {
+                        "type": "null",
+                        "value": null
+                    }
+                },
+                "tags": {
+                    "name": "tags",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "map",
+                        "value": null
+                    }
+                },
+                "health_check": {
+                    "name": "health_check",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "block",
+                        "value": null
+                    }
+                },
+                "stickiness": {
+                    "name": "stickiness",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "block",
+                        "value": null
+                    }
+                }
+            }
+        },
+        {
+            "action": "create",
+            "name": "default",
+            "type": "aws_ecs_service",
+            "fully_qualified_name": "aws_ecs_service.default",
+            "module_path": "",
+            "is_new": false,
+            "is_tainted": false,
+            "attributes": {
+                "cluster": {
+                    "name": "cluster",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "string",
+                        "value": "arn:aws:ecs:us-west-2:0001000200030004:cluster/test-cluster-0001000200030004-us-west-2"
+                    }
+                },
+                "deployment_maximum_percent": {
+                    "name": "deployment_maximum_percent",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "number",
+                        "value": "200"
+                    }
+                },
+                "deployment_minimum_healthy_percent": {
+                    "name": "deployment_minimum_healthy_percent",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "number",
+                        "value": "100"
+                    }
+                },
+                "desired_count": {
+                    "name": "desired_count",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "number",
+                        "value": "1"
+                    }
+                },
+                "launch_type": {
+                    "name": "launch_type",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "string",
+                        "value": "FARGATE"
+                    }
+                },
+                "platform_version": {
+                    "name": "platform_version",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "computed",
+                        "value": null
+                    }
+                },
+                "task_definition": {
+                    "name": "task_definition",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "string",
+                        "value": "arn:aws:ecs:us-west-2:0001000200030004:task-definition/myapp:7"
+                    }
+                },
+                "deployment_controller": {
+                    "name": "deployment_controller",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "block",
+                        "value": null
+                    }
+                },
+                "load_balancer": {
+                    "name": "load_balancer",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "block",
+                        "value": null
+                    }
+                },
+                "network_configuration": {
+                    "name": "network_configuration",
+                    "force_new_resource": false,
+                    "old": null,
+                    "new": {
+                        "type": "block",
+                        "value": null
+                    }
+                }
+            }
+        }
+    ],
+    "modules": []
+}

--- a/tests/.fixtures-0.12/67-deposed.stdout.txt
+++ b/tests/.fixtures-0.12/67-deposed.stdout.txt
@@ -1,0 +1,74 @@
+Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+------------------------------------------------------------------------
+
+Terraform will perform the following actions:
+
+  # aws_alb_target_group.ecs[0] (deposed object 08221b78) will be destroyed
+  - resource "aws_alb_target_group" "ecs" {
+      - arn                                = "arn:aws:elasticloadbalancing:us-west-2:0001000200030004:targetgroup/ecs-myapp/abcdefxyz" -> null
+      - deregistration_delay               = 10 -> null
+      - id                                 = "arn:aws:elasticloadbalancing:us-west-2:0001000200030004:targetgroup/ecs-myapp/abcdefxyz" -> null
+      - name                               = "ecs-myapp" -> null
+      - tags                               = {
+          - "application"  = "myapp"
+          - "environment"  = "test"
+          - "iac"          = "terraform"
+          - "owner-email"  = "terraform@example.com"
+        } -> null
+
+      - health_check {
+          - enabled             = true -> null
+          - healthy_threshold   = 2 -> null
+          - interval            = 15 -> null
+          - matcher             = "200" -> null
+          - path                = "/healthcheck" -> null
+          - port                = "traffic-port" -> null
+          - protocol            = "HTTP" -> null
+          - timeout             = 5 -> null
+          - unhealthy_threshold = 4 -> null
+        }
+
+      - stickiness {
+          - cookie_duration = 86400 -> null
+          - enabled         = false -> null
+          - type            = "lb_cookie" -> null
+        }
+    }
+
+  # aws_ecs_service.default will be created
+  + resource "aws_ecs_service" "default" {
+      + cluster                            = "arn:aws:ecs:us-west-2:0001000200030004:cluster/test-cluster-0001000200030004-us-west-2"
+      + deployment_maximum_percent         = 200
+      + deployment_minimum_healthy_percent = 100
+      + desired_count                      = 1
+      + launch_type                        = "FARGATE"
+      + platform_version                   = (known after apply)
+      + task_definition                    = "arn:aws:ecs:us-west-2:0001000200030004:task-definition/myapp:7"
+
+      + deployment_controller {
+          + type = "ECS"
+        }
+
+      + load_balancer {
+          + container_name   = "web"
+          + container_port   = 80
+          + target_group_arn = "arn:aws:elasticloadbalancing:us-west-2:0001000200030004:targetgroup/ecs-myapp/abcdefxyz"
+        }
+
+      + network_configuration {
+          + assign_public_ip = false
+          + security_groups  = [
+              + "sg-1234512345",
+            ]
+          + subnets          = [
+              + "subnet-abcdefabcdef",
+              + "subnet-xyzxyzxyzxyz",
+              + "subnet-abcxyz123456",
+            ]
+        }
+    }
+
+Plan: 1 to add, 0 to change, 1 to destroy.

--- a/tests/Terraform12OutputParserTest.php
+++ b/tests/Terraform12OutputParserTest.php
@@ -43,6 +43,7 @@ class Terraform12OutputParserTest extends TestCase
             'with-modules' => '63-modules',
             'tainted'      => '64-tainted',
             'no-changes'   => '65-no-changes',
+            'whitespace'   => '66-whitespace-changes',
         ];
 
         return array_map(function ($case) use ($fixturesDir) {

--- a/tests/Terraform12OutputParserTest.php
+++ b/tests/Terraform12OutputParserTest.php
@@ -44,6 +44,7 @@ class Terraform12OutputParserTest extends TestCase
             'tainted'      => '64-tainted',
             'no-changes'   => '65-no-changes',
             'whitespace'   => '66-whitespace-changes',
+            'deposed'      => '67-deposed',
         ];
 
         return array_map(function ($case) use ($fixturesDir) {


### PR DESCRIPTION
The following cases caused errors and were not correctly parsed:

- Comment line of a resource contains ` (deposed object abcdxyz)`
- An attribute contains ` # whitespace changes`

Examples:
```
-/+ resource "aws_sns_topic" "sns_topic" {
      ~ arn                                      = "arn:aws:sns:us-east-2:my-resource" -> (known after apply)
      ~ delivery_policy                          = jsonencode( # whitespace changes
            {
                http = {
                    defaultHealthyRetryPolicy    = {
                        backoffFunction    = "linear"
                        maxDelayTarget     = 20
                        minDelayTarget     = 20
                        numRetries         = 3
                    }
                }
            }
        )
    }

  # aws_alb_target_group.ecs[0] (deposed object 08221b78) will be destroyed
  - resource "aws_alb_target_group" "ecs" {
      - arn    = "arn:aws:elasticloadbalancing:us-west-2:my-resource" -> null
      - name   = "ecs-myapp" -> null
    }
```